### PR TITLE
Fix: upgrade Node.js to 22 in keep-supabase-active workflow

### DIFF
--- a/.github/workflows/keep-supabase-active.yml
+++ b/.github/workflows/keep-supabase-active.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install dependencies
         run: npm install @supabase/supabase-js
       - name: Ping Production Website


### PR DESCRIPTION
Node.js 20 lacks native WebSocket support required by @supabase/supabase-js, causing the ping job to fail. Node.js 22 has built-in WebSocket support and also satisfies the GitHub Actions Node.js 24 migration deadline (June 2026).